### PR TITLE
Fix typo in KDF pseudocode

### DIFF
--- a/noise.md
+++ b/noise.md
@@ -111,7 +111,7 @@ All Noise ciphersuites use the following HMAC-SHA2-512 based key derivation func
         output = []
         t = zeros[H_LEN]
         for c = 0...(ceil(output_len / H_LEN) - 1)
-            t = HMAC-SHA2-512(secret, info || (byte)c || t[0:32] || extra_secret)
+            t = HMAC-SHA2-512(secret, info || (byte)c || t[0:31] || extra_secret)
             output = output || t
         return output
 


### PR DESCRIPTION
As originally written, the first 33 bytes (0 -> 32) of the output are fed back in to the HMAC function. This feels like a typo. If the hash used has an output length equal to 32 (as allowed on line 101), this operation will fail.